### PR TITLE
get default timestamps for CustomWebserviceDataObject instead of fixe…

### DIFF
--- a/config/application.conf
+++ b/config/application.conf
@@ -10,7 +10,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1696854853&end=1697027653"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/config/application.conf.part-2-solution
+++ b/config/application.conf.part-2-solution
@@ -15,7 +15,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1696854853&end=1697027653"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/config/application.conf.part-3-solution
+++ b/config/application.conf.part-3-solution
@@ -20,12 +20,8 @@ dataObjects {
     nRetry = 5
     queryParameters = [{
       airport = "LSZB"
-      begin = 1630200800
-      end = 1630310979
     },{
       airport = "EDDF"
-      begin = 1630200800
-      end = 1630310979
     }]
     timeouts {
       connectionTimeoutMs = 200000

--- a/part3/config/application.conf
+++ b/part3/config/application.conf
@@ -17,12 +17,8 @@ dataObjects {
     nRetry = 5
     queryParameters = [{
       airport = "LSZB"
-      begin = 1630200800
-      end = 1630310979
     },{
       airport = "EDDF"
-      begin = 1630200800
-      end = 1630310979
     }]
     timeouts {
       connectionTimeoutMs = 200000

--- a/part3/src/main/scala/io/smartdatalake/workflow/dataobject/CustomWebserviceDataObject.scala.solution
+++ b/part3/src/main/scala/io/smartdatalake/workflow/dataobject/CustomWebserviceDataObject.scala.solution
@@ -23,7 +23,9 @@ import scala.annotation.tailrec
 import scala.util.{Failure, Success}
 
 case class HttpTimeoutConfig(connectionTimeoutMs: Int, readTimeoutMs: Int)
-case class DepartureQueryParameters(airport: String, begin: Long, end: Long)
+
+// Default to the interval of 2 days from now to today
+case class DepartureQueryParameters(airport: String, begin: Long = System.currentTimeMillis() / 1000 - 172800L, end: Long = System.currentTimeMillis() / 1000)
 
 case class State(airport: String, nextBegin: Long)
 
@@ -33,23 +35,23 @@ case class State(airport: String, nextBegin: Long)
 case class CustomWebserviceDataObject(override val id: DataObjectId,
                                       schema: String,
                                       queryParameters: Seq[DepartureQueryParameters],
-                                      additionalHeaders: Map[String,String] = Map(),
+                                      additionalHeaders: Map[String, String] = Map(),
                                       timeouts: Option[HttpTimeoutConfig] = None,
                                       authMode: Option[AuthMode] = None,
-                                      baseUrl : String,
+                                      baseUrl: String,
                                       nRetry: Int = 1,
                                       override val metadata: Option[DataObjectMetadata] = None
                                      )
                                      (@transient implicit val instanceRegistry: InstanceRegistry)
   extends DataObject with CanCreateSparkDataFrame with CanCreateIncrementalOutput with SmartDataLakeLogger {
 
-  private var previousState : Seq[State] = Seq()
-  private var nextState : Seq[State] = Seq()
+  private var previousState: Seq[State] = Seq()
+  private var nextState: Seq[State] = Seq()
 
   private val now = Instant.now.getEpochSecond
 
   @tailrec
-  private def request(url: String, method: WebserviceMethod = WebserviceMethod.Get, body: String = "", retry: Int = nRetry) : Array[Byte] = {
+  private def request(url: String, method: WebserviceMethod = WebserviceMethod.Get, body: String = "", retry: Int = nRetry): Array[Byte] = {
     val webserviceClient = ScalaJWebserviceClient(url, additionalHeaders, timeouts, authMode, proxy = None, followRedirects = true)
     val webserviceResult = method match {
       case WebserviceMethod.Get => webserviceClient.get()
@@ -60,12 +62,12 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
         logger.info(s"Success for request ${url}")
         c
       case Failure(e) =>
-        if(retry == 0) {
+        if (retry == 0) {
           logger.error(e.getMessage, e)
           throw new WebserviceException(e.getMessage)
         }
-        logger.info(s"Request will be repeated, because the server responded with: ${e.getMessage}. \nRequest retries left: ${retry-1}")
-        request(url, method, body, retry-1)
+        logger.info(s"Request will be repeated, because the server responded with: ${e.getMessage}. \nRequest retries left: ${retry - 1}")
+        request(url, method, body, retry - 1)
     }
   }
 
@@ -79,18 +81,18 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
 
     // if time interval is more than a week, set end config to 4 days after begin
     def checkQueryParameters(queryParameters: Seq[DepartureQueryParameters]) = {
-      queryParameters.map{
+      queryParameters.map {
         param =>
           val diff = param.end - param.begin
-          if(diff / (3600*24) >= 7) {
-            param.copy(end=param.begin+3600*24*4)
+          if (diff / (3600 * 24) >= 7) {
+            param.copy(end = param.begin + 3600 * 24 * 4)
           } else {
             param
           }
       }
     }
 
-    if(context.phase == ExecutionPhase.Init){
+    if (context.phase == ExecutionPhase.Init) {
       // simply return an empty data frame
       Seq[String]().toDF("responseString")
         .select(from_json($"responseString", DataType.fromDDL(schema)).as("response"))
@@ -100,14 +102,16 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
     } else {
       // place the new implementation of currentQueryParameters below this line
       // if we have query parameters in the state we will use them from now on
-      val currentQueryParameters = if (previousState.isEmpty) checkQueryParameters(queryParameters) else checkQueryParameters(previousState.map{
+      val currentQueryParameters = if (previousState.isEmpty) checkQueryParameters(queryParameters) else checkQueryParameters(previousState.map {
         x => DepartureQueryParameters(x.airport, x.nextBegin, now)
       })
 
       // given the query parameters, generate all requests
-      val departureRequests = currentQueryParameters.map(
+      val departureRequests: Seq[String] = currentQueryParameters.map(
         param => s"${baseUrl}?airport=${param.airport}&begin=${param.begin}&end=${param.end}"
       )
+
+      departureRequests.foreach(req => logger.info("Going to request: " + req))
       // make requests
       val departuresResponses = departureRequests.map(request(_))
       // create dataframe with the correct schema and add created_at column with the current timestamp


### PR DESCRIPTION
We currently have a problem in the getting-started guide that the requests to https://opensky-network.org/ do not work with older timestamps.
I now updated the timestamps to the most recent ones (begin=09-10-2023, end=11-10-2023).
Moreover, I explained this issue in the getting-started and told the user for part 1 to replace older timestamps in case of problems.
For part3 where we use a Custom Data Object, I implemented a default mechanism in the code that always gets recent timestamps. A pr with the documentation changes is this one: https://github.com/smart-data-lake/smart-data-lake/pull/735