### PR TITLE
Upgrade sdlb version in getting started guide to fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		  Set the smartdatalake version to use here.
 		  If version cannot be resolved, make sure maven central repository is defined in settings.xml and the corresponding profile activated.
 		-->
-		<version>2.7.1</version>
+		<version>2.7.2</version>
 	</parent>
 
 	<artifactId>getting-started</artifactId>


### PR DESCRIPTION
Currently, I'm getting the following error when trying to merge changes to the master branch of getting started. Probably it was fixed by your most recent change, @zzeekk so I simply suggest to upgrade.

`Run mvn -B exec:exec -Dexec.executable="java" -Dexec.args="$JAVA_OPTIONS -cp %classpath -DdataObjects.ext-departures.mockJsonDataObject=stg-departures-mock io.smartdatalake.app.LocalSmartDataLakeBuilder --feed-sel .* --config ./config,./envConfig/dev.conf --state-path viz/state -n getting-started --parallelism 2"
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< io.smartdatalake:getting-started >------------------
[INFO] Building SDL Getting Started 1.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- exec-maven-plugin:3.1.0:exec (default-cli) @ getting-started ---
2024-12-21 16:2[7](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:8):12 INFO  LocalSmartDataLakeBuilder$ - Starting LocalSmartDataLakeBuilder. This is an Alias for SparkSmartDataLakeBuilder. [main]
2024-12-21 16:27:12 WARN  BuildVersionInfo$ - Could not find resource app-version-info.properties [main]
2024-12-21 16:27:12 INFO  SparkSmartDataLakeBuilder$ - Starting Program SparkSmartDataLakeBuilder appVersion: version=2.[8](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:9).0-917-SNAPSHOT, sdlbVersion: version=2.8.0-[9](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:10)17-SNAPSHOT user=runner date=2024-12-10T22:57:00.529942578 revision=5e34e05c8e
 [main]
Error: Missing option --master
Error: Missing option --deploy-mode
Try --help for more information.
2024-12-21 16:27:14 ERROR SparkSmartDataLakeBuilder$ - Aborting SparkSmartDataLakeBuilder after error: ConfigurationException - Couldn't set command line parameters correctly. [main]
Error: Exception in thread "main" io.smartdatalake.config.ConfigurationException: Couldn't set command line parameters correctly.
	at io.smartdatalake.app.SmartDataLakeBuilder.throwOParserError(SmartDataLakeBuilder.scala:275)
	at io.smartdatalake.app.SparkSmartDataLakeBuilder$.main(SparkSmartDataLakeBuilder.scala:69)
	at io.smartdatalake.app.LocalSmartDataLakeBuilder$.main(LocalSmartDataLakeBuilder.scala:30)
	at io.smartdatalake.app.LocalSmartDataLakeBuilder.main(LocalSmartDataLakeBuilder.scala)
Error:  Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:[10](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:11)00)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:947)
    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:471)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:[11](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:12)7)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:[12](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:13)8)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:569)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.484 s
[INFO] Finished at: 2024-12-21T16:27:[14](https://github.com/smart-data-lake/getting-started/actions/runs/12446747117/job/34749479792#step:7:15)Z
[INFO] -----------------------------------------------------------------------`