### PR TITLE
Update training solution branch (#48)

### DIFF
--- a/envConfig/dev.conf
+++ b/envConfig/dev.conf
@@ -1,0 +1,11 @@
+
+# envConfig folder should have *one* configuration file per environment, holding environment specific settings.
+# These settings can be referenced in other configuration files using Hocon substitution, e.g. ${evn.database}.
+
+env {
+  catalog = null
+  database = default
+  basePath = "./"
+  basePathWithId = ${env.basePath}"~{id}"
+  tablePathWithId = ${env.basePathWithId}
+}

--- a/metastore/Dockerfile
+++ b/metastore/Dockerfile
@@ -9,7 +9,7 @@ apk update && \
 apk add bash && \
 apk add ca-certificates && update-ca-certificates && apk add openssl
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 
 WORKDIR /opt
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		  Set the smartdatalake version to use here.
 		  If version cannot be resolved, make sure maven central repository is defined in settings.xml and the corresponding profile activated.
 		-->
-		<version>2.7.2-896-SNAPSHOT</version>
+		<version>2.8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>getting-started</artifactId>

--- a/src/main/scala/com/sample/CustomWebserviceDataObject.scala
+++ b/src/main/scala/com/sample/CustomWebserviceDataObject.scala
@@ -12,7 +12,8 @@ import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.webservice.SttpUtil
 import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
-import io.smartdatalake.workflow.dataobject.{CanCreateSparkDataFrame, DataObject, DataObjectMetadata, HttpTimeoutConfig}
+import io.smartdatalake.workflow.dataobject.{CanCreateSparkDataFrame, DataObject, DataObjectMetadata}
+import io.smartdatalake.util.webservice.HttpTimeoutConfig
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.ArrayType


### PR DESCRIPTION
This pull request contains the following changes to resolve issue #48:
- Bump the version of SDLB to `2.8.1-SNAPSHOT`
- Update import in `src/main/scala/com/sample/CustomWebserviceDataObject.scala`
- Add the file `envConfig/dev.conf` such that there are no missing dependencies for the compilation using the `pom.xml`
